### PR TITLE
feat: Add VSCode Copilot Usage extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+plans/
+node_modules/
+out/
+*.vsix
+.vscode-test/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+	"version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "copilotignore"
+    ]
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,12 @@
+.vscode/**
+.vscode-test/**
+src/**
+.gitignore
+.yarnrc
+vsc-extension-quickstart.md
+**/tsconfig.json
+**/.eslintrc.json
+**/*.map
+**/*.ts
+!node_modules/**
+plans/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# VSCode Copilot Usage
+
+## 開発方針
+
+- **GitHub Flow準拠**: mainブランチへ直接コミット禁止。必ずfeatureブランチを作成すること。
+
+## アーキテクチャ
+
+### APIエンドポイント
+
+- `https://api.github.com/copilot_internal/user` はGitHub内部API
+- 変更される可能性があるため、将来的に修正が必要になる可能性あり
+
+### キャッシュ戦略
+
+- `globalState` を使用して複数ウィンドウ間でキャッシュを共有
+- `version` フィールドでAPIレスポンス構造変更時の互換性を管理
+- 現在のバージョン: `1.0`
+
+### タイマー設計
+
+- API呼び出し完了後にタイマーを再設定
+- これにより設定間隔（`refreshInterval`）を正確に守る
+- キャッシュヒット時はタイマー再設定なし
+
+### 使用率計算
+
+```typescript
+used = entitlement - quota_remaining
+percentage = (used / entitlement) * 100
+```
+
+データソース: `quota_snapshots.premium_interactions`

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# vscode-copilot-usage
+# VSCode Copilot Usage
+
+A VSCode extension that displays GitHub Copilot Premium Requests usage in the status bar.
+
+## Features
+
+- Displays Premium Requests usage percentage in the status bar (`Copilot: n%`)
+- Configurable refresh interval
+- Automatic GitHub authentication
+
+## Requirements
+
+- VSCode 1.85.0 or higher
+- GitHub account with Copilot subscription
+
+## Installation
+
+1. Open VSCode
+2. Press `F5` to launch Extension Development Host
+3. The extension will activate automatically
+
+## Configuration
+
+|            Setting             |  Type  | Default |           Description            |
+| ------------------------------ | ------ | ------- | -------------------------------- |
+| `copilotUsage.refreshInterval` | number | 60      | Data refresh interval in seconds |
+
+## Usage
+
+After installation, the extension will:
+1. Request GitHub authentication (if not already authenticated)
+2. Fetch your Copilot usage data
+3. Display the usage percentage in the status bar
+
+### Status Bar Display
+
+- `Copilot: n%` - Current usage percentage
+- `Copilot: -` - Unable to fetch data (error or unlimited plan)
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Compile TypeScript
+npm run compile
+
+# Watch for changes
+npm run watch
+```
+
+## License
+
+MIT

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["src/**/*.ts"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,222 @@
+{
+  "name": "vscode-copilot-usage",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-copilot-usage",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.6",
+        "@types/node": "^20.10.0",
+        "@types/vscode": "^1.85.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.6.tgz",
+      "integrity": "sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.6",
+        "@biomejs/cli-darwin-x64": "2.4.6",
+        "@biomejs/cli-linux-arm64": "2.4.6",
+        "@biomejs/cli-linux-arm64-musl": "2.4.6",
+        "@biomejs/cli-linux-x64": "2.4.6",
+        "@biomejs/cli-linux-x64-musl": "2.4.6",
+        "@biomejs/cli-win32-arm64": "2.4.6",
+        "@biomejs/cli-win32-x64": "2.4.6"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.6.tgz",
+      "integrity": "sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.6.tgz",
+      "integrity": "sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.6.tgz",
+      "integrity": "sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.6.tgz",
+      "integrity": "sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.6.tgz",
+      "integrity": "sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.6.tgz",
+      "integrity": "sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.6.tgz",
+      "integrity": "sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.6.tgz",
+      "integrity": "sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.110.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
+      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "vscode-copilot-usage",
+  "displayName": "VSCode Copilot Usage",
+  "description": "Display GitHub Copilot Premium Requests usage in the status bar",
+  "version": "0.0.1",
+  "publisher": "maedatakurou",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Copilot Usage",
+      "properties": {
+        "copilotUsage.refreshInterval": {
+          "type": "number",
+          "default": 60,
+          "description": "Data refresh interval in seconds (default: 60)"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "biome lint ./src",
+    "format": "biome format --write ./src",
+    "check": "biome check --write ./src"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.6",
+    "@types/node": "^20.10.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,251 @@
+import * as vscode from "vscode";
+
+// API Response Types
+interface QuotaSnapshot {
+  entitlement: number;
+  overage_count: number;
+  overage_permitted: boolean;
+  percent_remaining: number;
+  quota_id: string;
+  quota_remaining: number;
+  remaining: number;
+  unlimited: boolean;
+  timestamp_utc: string;
+}
+
+interface Organization {
+  login: string;
+  name: string;
+}
+
+interface Endpoints {
+  api: string;
+  "origin-tracker": string;
+  proxy: string;
+  telemetry: string;
+}
+
+interface QuotaSnapshots {
+  chat: QuotaSnapshot;
+  completions: QuotaSnapshot;
+  premium_interactions: QuotaSnapshot;
+}
+
+interface CopilotApiResponse {
+  login: string;
+  access_type_sku: string;
+  analytics_tracking_id: string;
+  assigned_date: string;
+  can_signup_for_limited: boolean;
+  chat_enabled: boolean;
+  copilotignore_enabled: boolean;
+  copilot_plan: string;
+  is_mcp_enabled: boolean;
+  organization_login_list: string[];
+  organization_list: Organization[];
+  restricted_telemetry: boolean;
+  endpoints: Endpoints;
+  quota_reset_date: string;
+  quota_snapshots: QuotaSnapshots;
+  quota_reset_date_utc: string;
+}
+
+// Cache Types
+const CACHE_VERSION = "1.0";
+
+interface CacheData {
+  version: string;
+  timestamp: number;
+  data: CopilotApiResponse;
+}
+
+// Usage Display Types
+interface UsageData {
+  percentage: number;
+  used: number;
+  entitlement: number;
+}
+
+const CACHE_KEY = "copilotUsage.cache";
+
+/**
+ * Activates the extension.
+ * @param context - The extension context provided by VSCode.
+ */
+export function activate(context: vscode.ExtensionContext) {
+  const statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100,
+  );
+  statusBarItem.command = undefined;
+  statusBarItem.text = "Copilot: ...";
+  statusBarItem.show();
+
+  function getCache(): CacheData | null {
+    const cache = context.globalState.get<CacheData>(CACHE_KEY);
+    if (!cache || cache.version !== CACHE_VERSION) {
+      return null;
+    }
+    return cache;
+  }
+
+  function setCache(data: CopilotApiResponse): void {
+    const cacheData: CacheData = {
+      version: CACHE_VERSION,
+      timestamp: Date.now(),
+      data,
+    };
+    context.globalState.update(CACHE_KEY, cacheData);
+  }
+
+  function isCacheValid(cache: CacheData | null): boolean {
+    if (!cache) {
+      return false;
+    }
+    const refreshIntervalMs = getRefreshInterval();
+    return Date.now() - cache.timestamp < refreshIntervalMs;
+  }
+
+  function extractUsageData(data: CopilotApiResponse): UsageData | null {
+    const premiumInteractions = data.quota_snapshots?.premium_interactions;
+
+    if (!premiumInteractions) {
+      return null;
+    }
+
+    const { entitlement, quota_remaining } = premiumInteractions;
+
+    if (entitlement === 0) {
+      return null;
+    }
+
+    const used = entitlement - quota_remaining;
+    const percentage = (used / entitlement) * 100;
+
+    return {
+      percentage: Math.round(percentage * 10) / 10,
+      used,
+      entitlement,
+    };
+  }
+
+  async function fetchFromApi(): Promise<CopilotApiResponse | null> {
+    try {
+      const session = await vscode.authentication.getSession(
+        "github",
+        ["user:email"],
+        {
+          createIfNone: true,
+        },
+      );
+
+      if (!session) {
+        return null;
+      }
+
+      const response = await fetch(
+        "https://api.github.com/copilot_internal/user",
+        {
+          headers: {
+            Authorization: `Bearer ${session.accessToken}`,
+            "User-Agent": "VSCode-Copilot-Usage-Extension",
+          },
+        },
+      );
+
+      if (!response.ok) {
+        console.error(
+          "[Copilot Usage] API error:",
+          response.status,
+          await response.text(),
+        );
+        return null;
+      }
+
+      const data: CopilotApiResponse = await response.json();
+      return data;
+    } catch (error) {
+      console.error("[Copilot Usage] Error:", error);
+      return null;
+    }
+  }
+
+  async function fetchUsage(): Promise<{
+    usage: UsageData | null;
+    apiCalled: boolean;
+  }> {
+    const cache = getCache();
+
+    if (cache && isCacheValid(cache)) {
+      return { usage: extractUsageData(cache.data), apiCalled: false };
+    }
+
+    const apiData = await fetchFromApi();
+
+    if (apiData) {
+      setCache(apiData);
+      return { usage: extractUsageData(apiData), apiCalled: true };
+    }
+
+    // Fallback to expired cache if API fails
+    if (cache) {
+      return { usage: extractUsageData(cache.data), apiCalled: false };
+    }
+
+    return { usage: null, apiCalled: false };
+  }
+
+  async function updateStatusBar() {
+    const { usage, apiCalled } = await fetchUsage();
+
+    if (usage === null) {
+      statusBarItem.text = "Copilot: -";
+      statusBarItem.tooltip = "Unable to fetch Copilot usage data";
+    } else {
+      statusBarItem.text = `Copilot: ${usage.percentage}%`;
+      statusBarItem.tooltip = `Premium Requests: ${usage.percentage}% (${usage.used}/${usage.entitlement})`;
+    }
+
+    if (apiCalled) {
+      startInterval();
+    }
+  }
+
+  function getRefreshInterval(): number {
+    const config = vscode.workspace.getConfiguration("copilotUsage");
+    const seconds = config.get<number>("refreshInterval", 60);
+    return seconds * 1000;
+  }
+
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+
+  function startInterval() {
+    if (intervalId !== undefined) {
+      clearInterval(intervalId);
+    }
+    intervalId = setInterval(updateStatusBar, getRefreshInterval());
+  }
+
+  updateStatusBar();
+  startInterval();
+
+  context.subscriptions.push(
+    statusBarItem,
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("copilotUsage.refreshInterval")) {
+        startInterval();
+      }
+    }),
+    {
+      dispose: () => {
+        if (intervalId !== undefined) clearInterval(intervalId);
+      },
+    },
+  );
+}
+
+/**
+ * Deactivates the extension.
+ * Called when VSCode is shutting down or the extension is disabled.
+ */
+export function deactivate() {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary
- Display Premium Requests usage percentage in the status bar
- Support configurable refresh interval (default: 60 seconds)
- Implement global cache for multi-window API call reduction
- Add JSDoc documentation for exported functions
- Configure biome for linting and formatting

## Test plan
- [x] Extension activates successfully
- [x] Status bar displays usage percentage (e.g., "Copilot: 33.3%")
- [x] GitHub authentication works
- [x] Refresh interval configuration works
- [ ] Multiple windows share cache correctly

## 🤖 Generated with [Claude Code](https://claude.com/claude-code)