### PR TITLE
fix: add ci-status job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,15 @@ jobs:
 
       - name: Compile TypeScript
         run: npm run compile
+
+  ci-status:
+    name: CI status check
+    runs-on: ubuntu-latest
+    needs: [check, typecheck, build]
+    if: always()
+    steps:
+      - name: Some checks failed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+      - name: All checks passed
+        run: exit 0


### PR DESCRIPTION
## Summary
- Add `ci-status` job that aggregates all CI check results (check, typecheck, build)
- Enables Branch Protection Rules to use a single status check instead of multiple

## Test plan
- [x] Verify CI workflow runs successfully
- [x] Confirm ci-status job passes when all checks pass
- [x] Confirm ci-status job fails when any check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)