### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.0] - 2026-05-19
+
+### Added
+
+- Add PAT (Personal Access Token) authentication as primary method
+- Add `Set PAT` and `Clear PAT` commands with API verification
+- Store PAT securely in VSCode SecretStorage
+- Show account ID in status bar tooltip
+
+### Changed
+
+- Use GitHub OAuth as fallback when no PAT is configured
+- Stop polling timer when no auth credentials are available
+
+
 ## [0.4.1] - 2026-03-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-copilot-usage",
   "displayName": "VSCode Copilot Usage",
   "description": "Display GitHub Copilot Premium Requests usage in the status bar",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "publisher": "j4rviscmd",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary

Release v0.5.0

### Added
- Add PAT (Personal Access Token) authentication as primary method
- Add `Set PAT` and `Clear PAT` commands with API verification
- Store PAT securely in VSCode SecretStorage
- Show account ID in status bar tooltip

### Changed
- Use GitHub OAuth as fallback when no PAT is configured
- Stop polling timer when no auth credentials are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)