### PR TITLE
docs: add archived project warning to README

### DIFF
--- a/.forest.toml
+++ b/.forest.toml
@@ -1,0 +1,6 @@
+[start]
+# commands = ["npm install"]
+# share = [".env", "node_modules"]
+
+[finish]
+# commands = ["npm install"]

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out/
 .vscode-test/
 .DS_Store
 CLAUDE.md
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> **Archived Project**<br/>
+> GitHub Copilot transitioned from request-based billing to token-based billing on June 1, 2026.<br/>
+> I consider this change a downgrade and have cancelled my subscription, so this extension is now archived and will no longer be maintained.
+
 <div align="center">
 
 # VSCode Copilot Usage


### PR DESCRIPTION
## Summary

Add a warning banner to the top of README indicating that this extension has been archived.

## Context

GitHub Copilot transitioned from request-based billing to token-based billing on June 1, 2026. The author considers this change a downgrade and has cancelled the subscription, making this extension no longer needed.

## Changes

- Add `> [!WARNING]` block at the top of README.md with archived project notice